### PR TITLE
refactor(bindings.ts): prefer idempotent ata instruction for referrer

### DIFF
--- a/js/src/bindings.ts
+++ b/js/src/bindings.ts
@@ -50,7 +50,7 @@ import {
 import {
   TOKEN_PROGRAM_ID,
   getAssociatedTokenAddressSync,
-  createAssociatedTokenAccountInstruction,
+  createAssociatedTokenAccountIdempotentInstruction,
 } from "@solana/spl-token";
 import { ErrorType, SNSError } from "./error";
 import { serializeRecord, serializeSolRecord } from "./record";
@@ -317,7 +317,7 @@ export const registerDomainName = async (
     refTokenAccount = getAssociatedTokenAddressSync(mint, referrerKey, true);
     const acc = await connection.getAccountInfo(refTokenAccount);
     if (!acc?.data) {
-      const ix = createAssociatedTokenAccountInstruction(
+      const ix = createAssociatedTokenAccountIdempotentInstruction(
         buyer,
         refTokenAccount,
         referrerKey,


### PR DESCRIPTION
This PR affects handling of a referrer's associated token account in the ```registerDomainName``` function.

The motive behind this PR emerged because of the following train-of-thought that can be seen in the sns-widget cart view [index.ts](https://github.com/Bonfida/sns-widget/blob/7d6e10b984da62d056933b6b6dee41db329447a7/src/lib/views/cart/index.tsx#L149);

Context: If a referrer **does not** have an associated token account for a given mint and the following steps occur;

1. registerDomainName is called in a for-loop where ```TransactionInstruction``` are accumulated outside of the for-loop
2. Transaction instructions are chunked-off
3. Batch transactions are executed
4. Transactions after the first transaction will fail

Reason:

- registerDomainName calls ```getAccountInfo``` for the associated token account. Given it has not been initialized, the ```createAssociatedTokenAccountInstruction``` will exist for every transaction.
- ```createAssociatedTokenAccountInstruction``` **will fail on subsequent transactions** as per spec [**Returns an error if the account exists.**](https://docs.rs/spl-associated-token-account/latest/spl_associated_token_account/instruction/enum.AssociatedTokenAccountInstruction.html#variant.Create)

Proposal:

- Use ```createAssociatedTokenAccountIdempotentInstruction```. See [CreateIdempotent](https://docs.rs/spl-associated-token-account/latest/spl_associated_token_account/instruction/enum.AssociatedTokenAccountInstruction.html#variant.CreateIdempotent).
Do keep in mind ```CreateIdempotent``` --> ```Returns an error if the account exists, but with a different owner```.

Final notes:

- **This has not been tested**. It has only emerged to me from the train-of-thought above. Interested to hear feedback on this.