### PR TITLE
Fix: Add fallback value when Solana v2 record unverified

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "sns-sdk",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Fixes error where resolution fails completely if a SOL v2 record is unverified. Instead of throwing an error immediately, we return the registry owner as a fallback, and log the error. 